### PR TITLE
:sparkles: Added argument to redirect output to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,5 @@ dmypy.json
 .pyre/
 
 # End of https://www.gitignore.io/api/python,pycharm
+
+output.txt

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ To execute Commity, you might need to specify some arguments:
 the current folder is taken.
 * `-b` or `--branch`: The name of the branch where to get the
 commits. By default, the current branch is taken.
+* `-o` or `--output`: The output file. All information will be written in the
+given file. If the file is invalid, or no file is given, stdout is used instead.
 
 **Example:**
 
-`python commity.py -r C:\Users\Foo\MyProject -b feat/gui-buttons`
+`python commity.py -r C:\Users\Foo\MyProject -b feat/gui-buttons -o output.txt`
 
 ## Built With
 


### PR DESCRIPTION
* The arguments `-o` or `--output` can now be used to redirect all the output to a given file. It also support emojis.